### PR TITLE
Added context path to javascipt sources and ajax request

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ organization := "net.liftmodules"
 
 homepage := Some(url("https://github.com/joescii/lift-ng"))
 
-version := "0.4.6"
+version := "0.4.7"
 
 liftVersion <<= liftVersion ?? "2.5.1"
 

--- a/src/main/js/liftproxy.js
+++ b/src/main/js/liftproxy.js
@@ -43,7 +43,8 @@ angular
           return q.promise;
         };
 
-        return $http.post('ajax_request/' + lift_page + '/', req, {
+        return $http.post(net_liftmodules_ng.contextPath + '/ajax_request/' + lift_page + '/', req, {
+        //return $http.post('ajax_request/' + lift_page + '/', req, {
           headers : {
             'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
           }

--- a/src/main/scala/net/liftmodules/ng/Angular.scala
+++ b/src/main/scala/net/liftmodules/ng/Angular.scala
@@ -89,7 +89,7 @@ object Angular extends DispatchSnippet {
   }
 
   private val liftproxySrc =
-    "classpath/net/liftmodules/ng/js/liftproxy-"+BuildInfo.version + (Props.mode match {
+    LiftRules.context.path + "/classpath/net/liftmodules/ng/js/liftproxy-"+BuildInfo.version + (Props.mode match {
       case RunModes.Development => ".js"
       case _ => ".min.js"
     })
@@ -108,6 +108,7 @@ object Angular extends DispatchSnippet {
     val liftproxy = if(includeJsScript) <script src={liftproxySrc}></script> else NodeSeq.Empty
     val jsModule = Script(JsRaw(
       "var net_liftmodules_ng=net_liftmodules_ng||{};" +
+      "net_liftmodules_ng.contextPath=net_liftmodules_ng.contextPath||\"" + LiftRules.context.path + "\";" +
       "net_liftmodules_ng.version=net_liftmodules_ng.version||\"" + BuildInfo.version + "\";" +
       "net_liftmodules_ng.jsPath=net_liftmodules_ng.jsPath||\"" + liftproxySrc +"\";"
     ))

--- a/test-project/build.sbt
+++ b/test-project/build.sbt
@@ -2,7 +2,7 @@ name := "ng-test"
 
 organization := "net.liftmodules"
 
-version := "0.4.6"
+version := "0.4.7"
 
 liftVersion <<= liftVersion ?? "2.5.1"
 

--- a/test-project/src/main/scala/bootstrap/liftweb/Boot.scala
+++ b/test-project/src/main/scala/bootstrap/liftweb/Boot.scala
@@ -39,7 +39,8 @@ class Boot {
       Menu.i("Actors - Scope") / "actorsScope",
       Menu.i("Actors - Assignment") / "actorsAssignment",
       Menu.i("Delay") / "delay",
-      Menu.i("head.js") / "head-js"
+      Menu.i("head.js") / "head-js",
+      Menu.i("Subdir") / "subdir" / "index"
     )
 
     // set the sitemap.  Note if you don't want access control for

--- a/test-project/src/main/webapp/subdir/index.html
+++ b/test-project/src/main/webapp/subdir/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head><meta content="text/html; charset=UTF-8" http-equiv="content-type" /><title>Home</title></head>
+  <body class="lift:content_id=main">
+    <div id="main" class="lift:surround?with=default;at=content">
+      <script data-lift="AngularJS"></script>
+      <script id="liftmodules-ng_js"  data-lift="Angular"></script>
+      <script id="staticServices_js"                                      type="text/javascript" data-lift="StaticServices"></script>
+      <script id="staticApp_js"       src="/js/StaticApp.js"              type="text/javascript"></script>
+
+      <h2>Static service tests (in Subdir)</h2>
+      <div ng-app="StaticApp">
+        <div ng-controller="TestController">
+          <span id="outputStr" ng-bind="outputStr">OutputStr</span>
+          <span id="outputInt" ng-bind="outputInt">OutputInt</span>
+          <span id="outputStrField" ng-bind="outputObj.str">OutputStrField</span>
+          <span id="outputIntField" ng-bind="outputObj.num">OutputIntField</span>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>
+


### PR DESCRIPTION
Using relative paths leads to errors when using subdirectories. But switching back to absolute paths without adding the context path would revive Issue #2. As the context path needs to be known also when performing request from inside the angular module "lift-ng" it was made known through the global variable "net_liftmodules_ng.contextPath".
