### PR TITLE
Lift 3.1 update

### DIFF
--- a/README.md
+++ b/README.md
@@ -927,7 +927,6 @@ These functions have been introduced ahead of the macro for the sake of allowing
 * *0.9.4*: Updates for compatibility with latest Lift 3.1.0 milestone (M1 in particular).
 Lift 3.0 was updated to 3.0.1 instead of the previous release candidate.
 A recompile of the plugin against Lift 3.1.0-M1 also resolved some bytecode-level issues.
-Added support for Scala 2.12 against Lift editions 3.0 and 3.1.
 * *0.9.3*: Updates for compatibility with latest Lift 3.0 release candidate (RC3 in particular).
 Lift-json call has been updated per Lift framework [PR 1766](https://github.com/lift/framework/pull/1766).
 A recompile of the plugin against Lift 3.0-RC3 also resolved some bytecode-level issues.

--- a/README.md
+++ b/README.md
@@ -924,7 +924,10 @@ The macro described above will rewrite `defs` into a chain of these six function
 These functions have been introduced ahead of the macro for the sake of allowing the implicit JSON `Formats` parameter to be provided (see [JSON Serialization](#json-serialization)).
 
 ## Change log
-
+* *0.9.4*: Updates for compatibility with latest Lift 3.1.0 milestone (M1 in particular).
+Lift 3.0 was updated to 3.0.1 instead of the previous release candidate.
+A recompile of the plugin against Lift 3.1.0-M1 also resolved some bytecode-level issues.
+Added support for Scala 2.12 against Lift editions 3.0 and 3.1.
 * *0.9.3*: Updates for compatibility with latest Lift 3.0 release candidate (RC3 in particular).
 Lift-json call has been updated per Lift framework [PR 1766](https://github.com/lift/framework/pull/1766).
 A recompile of the plugin against Lift 3.0-RC3 also resolved some bytecode-level issues.

--- a/build.sbt
+++ b/build.sbt
@@ -4,9 +4,9 @@ organization := "net.liftmodules"
 
 homepage := Some(url("https://github.com/joescii/lift-ng"))
 
-version := "0.9.3"
+version := "0.9.4"
 
-liftVersion <<= liftVersion ?? "2.6.3"
+liftVersion <<= liftVersion ?? "3.1.0-M1"
 
 liftEdition <<= liftVersion { _.substring(0,3) }
 
@@ -16,9 +16,9 @@ name <<= (name, liftEdition) { (n, e) =>  n + "_" + e }
 // E.g. "2.5" gets converted to "2-5"
 moduleName := name.value
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.11.8"
 
-crossScalaVersions := Seq("2.11.7", "2.10.5", "2.9.2", "2.9.1")
+crossScalaVersions := Seq("2.11.8", "2.10.5", "2.9.2", "2.9.1")
 
 resolvers += "CB Central Mirror" at "http://repo.cloudbees.com/content/groups/public"
 

--- a/notes/0.9.4.markdown
+++ b/notes/0.9.4.markdown
@@ -5,4 +5,3 @@
 Updates for compatibility with latest Lift 3.1.0 milestone (M1 in particular).
 Lift 3.0 was updated to 3.0.1 instead of the previous release candidate.
 A recompile of the plugin against Lift 3.1.0-M1 also resolved some bytecode-level issues.
-Added support for Scala 2.12 against Lift editions 3.0 and 3.1.

--- a/notes/0.9.4.markdown
+++ b/notes/0.9.4.markdown
@@ -1,0 +1,8 @@
+#liftng
+
+#scala @liftweb @angularjs
+
+Updates for compatibility with latest Lift 3.1.0 milestone (M1 in particular).
+Lift 3.0 was updated to 3.0.1 instead of the previous release candidate.
+A recompile of the plugin against Lift 3.1.0-M1 also resolved some bytecode-level issues.
+Added support for Scala 2.12 against Lift editions 3.0 and 3.1.

--- a/publish.txt
+++ b/publish.txt
@@ -3,14 +3,20 @@ alias pub=publishSigned
 clean 
 jasmine
 
-set liftVersion in ThisBuild :="3.0-RC3"
-set crossScalaVersions := Seq("2.11.7")
+set liftVersion in ThisBuild :="3.1.0-M1"
+set crossScalaVersions := Seq("2.11.8")
++ update
++ test
++ pub
+
+set liftVersion in ThisBuild :="3.0.1"
+set crossScalaVersions := Seq("2.11.8")
 + update
 + test
 + pub
 
 set liftVersion in ThisBuild:="2.6.3"
-set crossScalaVersions := Seq("2.11.7", "2.10.5", "2.9.2", "2.9.1")
+set crossScalaVersions := Seq("2.11.8", "2.10.5", "2.9.2", "2.9.1")
 + update
 + test
 + pub


### PR DESCRIPTION
When I attempted to use 0.9.3 with Lift 3.1.0 I received the following exception:

```
Exception in thread "main" java.lang.NoSuchMethodError: net.liftweb.common.Box.openOrThrowException(Ljava/lang/String;)Ljava/lang/Object;
  at net.liftmodules.ng.AngularJsRest$.init(AngularJsRest.scala:13)
```

After compiling my own version and publishing it locally for Lift 3.1.0 it worked as expected.

This pull request updates the project to also build with Lift 3.1.0.  I did attempt to add support for Scala 2.12 but realized ScalaTest only has version 3.x available for Scala 2.12, 2.11 and 2.10. It seems the should matchers were deprecated between versions 2.x and 3.x.  Unfortunately, since 3.x does not support Scala < 2.10 I am not sure how to proceed.  Maybe we should follow the Lift project's lead and start only supporting Scala 2.11 and 2.12 with future releases?
