### PR TITLE
Address SBT and Specs Warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ version := "0.10.2"
 
 val liftVersion = SettingKey[String]("liftVersion", "Full version number of the Lift Web Framework")
 val liftEdition = SettingKey[String]("liftEdition", "Lift Edition (short version number to append to artifact name)")
-liftVersion <<= liftVersion ?? "3.1.0"
+liftVersion := (liftVersion ?? "3.1.0").value
 liftEdition := liftVersion.value.substring(0,3)
 
 name := name.value + "_" + liftEdition.value
@@ -127,5 +127,3 @@ jasmineConfFile += sourceDirectory { src => src / "test" / "js" / "3rdlib" / "te
 jasmineRequireJsFile += sourceDirectory { src => src / "test" / "js" / "3rdlib" / "require" / "require-2.0.6.js" }.value
 
 jasmineRequireConfFile += sourceDirectory { src => src / "test" / "js" / "3rdlib" / "require.conf.js" }.value
-
-scalacOptions in ThisBuild ++= Seq("-unchecked", "-deprecation")

--- a/build.sbt
+++ b/build.sbt
@@ -63,7 +63,7 @@ excludeFilter in unmanagedSources := {
 
 buildInfoSettings
 
-sourceGenerators in Compile <+= buildInfo
+sourceGenerators in Compile += buildInfo
 
 buildInfoKeys := Seq[BuildInfoKey](version, liftVersion, liftEdition)
 
@@ -106,26 +106,26 @@ pomExtra := (
 
 licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.html"))
 
-seq(com.untyped.sbtjs.Plugin.jsSettings : _*)
+Seq(com.untyped.sbtjs.Plugin.jsSettings : _*)
 (sourceDirectory in (Compile, JsKeys.js)) := (sourceDirectory in Compile).value / "js"
 (resourceManaged in (Compile, JsKeys.js)) := (resourceManaged in Compile).value / "toserve" / "net" / "liftmodules" / "ng" / "js"
 (JsKeys.filenameSuffix in Compile) :=  "-" + version.value + ".min"
-(resourceGenerators in Compile) <+= (JsKeys.js in Compile)
+(resourceGenerators in Compile) += (JsKeys.js in Compile)
 copyJs
 
 // Jasmine stuff
-seq(jasmineSettings : _*)
+Seq(jasmineSettings : _*)
 
-appJsDir <+= sourceDirectory { src => src / "main" / "js" }
+appJsDir += sourceDirectory { src => src / "main" / "js" }.value
 
-appJsLibDir <+= sourceDirectory { src => src / "test" / "js" / "3rdlib" }
+appJsLibDir += sourceDirectory { src => src / "test" / "js" / "3rdlib" }.value
 
-jasmineTestDir <+= sourceDirectory { src => src /  "test" / "js" }
+jasmineTestDir += sourceDirectory { src => src /  "test" / "js" }.value
 
-jasmineConfFile <+= sourceDirectory { src => src / "test" / "js" / "3rdlib" / "test.dependencies.js" }
+jasmineConfFile += sourceDirectory { src => src / "test" / "js" / "3rdlib" / "test.dependencies.js" }.value
 
-jasmineRequireJsFile <+= sourceDirectory { src => src / "test" / "js" / "3rdlib" / "require" / "require-2.0.6.js" }
+jasmineRequireJsFile += sourceDirectory { src => src / "test" / "js" / "3rdlib" / "require" / "require-2.0.6.js" }.value
 
-jasmineRequireConfFile <+= sourceDirectory { src => src / "test" / "js" / "3rdlib" / "require.conf.js" }
+jasmineRequireConfFile += sourceDirectory { src => src / "test" / "js" / "3rdlib" / "require.conf.js" }.value
 
-//(Keys.test in Test) <<= (Keys.test in Test) dependsOn (jasmine)
+scalacOptions in ThisBuild ++= Seq("-unchecked", "-deprecation")

--- a/src/main/scala/net/liftmodules/ng/Angular.scala
+++ b/src/main/scala/net/liftmodules/ng/Angular.scala
@@ -269,7 +269,7 @@ object Angular extends DispatchSnippet with AngularProperties with LiftNgJsHelpe
 
   private [ng] def plumbFuture[T <: Any](f: LAFuture[Box[T]], id:String)(implicit formats: Formats) = {
     S.session map { s => f foreach { box =>
-      s.sendCometActorMessage("LiftNgFutureActor", Empty, ReturnData(id, box, formats))
+      s.sendCometMessage("LiftNgFutureActor", Empty, ReturnData(id, box, formats))
     }}
     f
   }

--- a/src/main/scala/net/liftmodules/ng/LAFutureSerializer.scala
+++ b/src/main/scala/net/liftmodules/ng/LAFutureSerializer.scala
@@ -28,7 +28,7 @@ object LAFutureSerializer {
   }
 
   def laFutureSerializer(formats: Formats): PartialFunction[Any, JValue] = {
-    case future: LAFuture[Box[_]] => laFuture2JValue(formats, future)
+    case future: LAFuture[Box[_]] => laFuture2JValue(formats, future)  //Throws type erasure warning (may not be a Box)
   }
 
 }
@@ -46,7 +46,7 @@ class LAFutureSerializer[T <: NgModel : Manifest] extends Serializer[LAFuture[Bo
 
   // The stuff below was copy/pasted from CustomSerializer.  Because we need to recursively call ourselves,
   // it's not possible to use CustomSerializer.
-  val Class = implicitly[Manifest[LAFuture[Box[T]]]].erasure
+  val Class = implicitly[Manifest[LAFuture[Box[T]]]].runtimeClass
 
   def deserialize(implicit format: Formats) = {
     case (TypeInfo(Class, _), json) =>

--- a/src/test/scala/net/liftmodules/ng/FutureConversionsSpecs_2.10.scala
+++ b/src/test/scala/net/liftmodules/ng/FutureConversionsSpecs_2.10.scala
@@ -1,15 +1,14 @@
 package net.liftmodules.ng
 
-import org.scalatest.WordSpec
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.{Matchers, WordSpec}
 import net.liftweb.common._
 import net.liftweb.actor.LAFuture
-import scala.concurrent.Future
 
+import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 
 
-class FutureConversionsSpecs extends WordSpec with ShouldMatchers {
+class FutureConversionsSpecs extends WordSpec with Matchers {
   "The Scala Future => LAFuture converter" should {
     import FutureConversions._
 

--- a/src/test/scala/net/liftmodules/ng/LAFutureSerializerSpecs.scala
+++ b/src/test/scala/net/liftmodules/ng/LAFutureSerializerSpecs.scala
@@ -1,7 +1,7 @@
 package net.liftmodules.ng
 
 import org.scalatest._
-import matchers.ShouldMatchers
+import org.scalatest.Matchers
 import net.liftweb.json.{JsonParser, Serialization, NoTypeHints}
 import Serialization.write
 import net.liftweb.actor.LAFuture
@@ -12,7 +12,7 @@ case class Test[T](f:LAFuture[Box[T]])
 case class Model(str:String, num:Int)
 case class ModelF(str:String, num:Int, f:LAFuture[Box[String]])
 
-class LAFutureSerializerSpecs extends WordSpec with ShouldMatchers {
+class LAFutureSerializerSpecs extends WordSpec with Matchers {
   import AngularExecutionContext._
   implicit val formats = Serialization.formats(NoTypeHints) + new LAFutureSerializer
 

--- a/src/test/scala/net/liftmodules/ng/ScalaFutureSerializerSpecs_2.10.scala
+++ b/src/test/scala/net/liftmodules/ng/ScalaFutureSerializerSpecs_2.10.scala
@@ -1,17 +1,17 @@
 package net.liftmodules.ng
 
-import org.scalatest.WordSpec
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.{Matchers, WordSpec}
 import net.liftweb.json.{JsonParser, NoTypeHints, Serialization}
 import net.liftweb.json.Serialization._
-import net.liftweb.json.JsonAST.{JString, JBool, JField, JObject}
-import scala.concurrent.{Promise, Future}
+import net.liftweb.json.JsonAST.{JBool, JField, JObject, JString}
+
+import scala.concurrent.{Future, Promise}
 import org.scalatest.concurrent.Eventually
 
 case class TestScala[T](f:Future[T])
 case class ModelScalaF(str:String, num:Int, f:Future[String])
 
-class ScalaFutureSerializerSpecs extends WordSpec with ShouldMatchers with Eventually {
+class ScalaFutureSerializerSpecs extends WordSpec with Matchers with Eventually {
   import AngularExecutionContext._
   implicit val formats = Serialization.formats(NoTypeHints) + new LAFutureSerializer
   import scala.concurrent.ExecutionContext.Implicits.global

--- a/src/test/scala/net/liftmodules/ng/js/JsonDeltaFunctionSpecs.scala
+++ b/src/test/scala/net/liftmodules/ng/js/JsonDeltaFunctionSpecs.scala
@@ -12,7 +12,7 @@ import json.JsonAST._
 import org.scalatest._
 import matchers.ShouldMatchers
 
-class JsonDeltaFuncExamples extends WordSpec with ShouldMatchers {
+class JsonDeltaFuncExamples extends WordSpec with Matchers {
   "JsonDeltaFunctions (dfs)" should {
     "Same values" in {
       val dfn = JString("same") dfn JString("same")

--- a/src/test/scala/net/liftmodules/ng/js/JsonExtractMergedSpecs.scala
+++ b/src/test/scala/net/liftmodules/ng/js/JsonExtractMergedSpecs.scala
@@ -6,7 +6,7 @@ import net.liftweb.json._
 
 case class Test(a:String, b:Int)
 
-class JsonExtractMergedSpecs extends FlatSpecLike with ShouldMatchers {
+class JsonExtractMergedSpecs extends FlatSpecLike with Matchers {
   implicit val formats = DefaultFormats
 
   "This code" should "work" in {

--- a/test-project/build.sbt
+++ b/test-project/build.sbt
@@ -7,7 +7,7 @@ version := "0.10.2"
 val liftVersion = SettingKey[String]("liftVersion", "Full version number of the Lift Web Framework")
 val liftEdition = SettingKey[String]("liftEdition", "Lift Edition (short version number to append to artifact name)")
 liftVersion := System.getProperty("lift.version", "2.6.3")
-liftEdition <<= liftVersion { _.substring(0,3) }
+liftEdition := liftVersion.value.substring(0,3)
 
 scalaVersion := System.getProperty("scala.version", "2.11.11")
 
@@ -19,11 +19,11 @@ resolvers ++= Seq(
   "releases"  at "https://oss.sonatype.org/content/repositories/releases"
 )
 
-seq(webSettings :_*)
+Seq(webSettings :_*)
 
-unmanagedResourceDirectories in Test <+= (baseDirectory) { _ / "src/main/webapp" }
+unmanagedResourceDirectories in Test += (baseDirectory) { _ / "src/main/webapp" }.value
 
-libraryDependencies <++= (liftVersion, version) { (lift, liftng) =>
+libraryDependencies ++= (liftVersion, version) { (lift, liftng) =>
   val liftEdition = lift.substring(0,3)
   val jqEdition = if(liftEdition startsWith "3") "3.0" else liftEdition
   val jq = if(liftEdition == "2.5") "2.8" else "2.9"
@@ -32,27 +32,6 @@ libraryDependencies <++= (liftVersion, version) { (lift, liftng) =>
     "net.liftmodules"         %%  ("lift-jquery-module_"+jqEdition)   % jq                    % "compile",
     "net.liftmodules"         %%  ("ng_"+liftEdition)                 % liftng                % "compile", // https://github.com/joescii/lift-ng
     "org.webjars"             %   "angularjs"                         % "1.4.8",
-//    "org.webjars.bower"             %   "angularjs"                         % "1.4.7",
-//    "org.webjars.bower"             %   "angular"                         % "1.4.7",
-//    "org.webjars.bower"             %   "angular-aria"                         % "1.4.7",
-//    "org.webjars.bower"             %   "angular-animate"                         % "1.4.7",
-//    "org.webjars.bower"             %   "angular-cookies"                         % "1.4.7",
-//    "org.webjars.bower"             %   "angular-loader"                         % "1.4.7",
-//    "org.webjars.bower"             %   "angular-messages"                         % "1.4.7",
-//    "org.webjars.bower"             %   "angular-resource"                         % "1.4.7",
-//    "org.webjars.bower"             %   "angular-route"                         % "1.4.7",
-//    "org.webjars.bower"             %   "angular-sanitize"                         % "1.4.7",
-//    "org.webjars.bower"             %   "angular-touch"                         % "1.4.7",
-//    "org.webjars.npm"             %   "angular"                         % "1.4.7",
-//    "org.webjars.npm"             %   "angular-aria"                         % "1.4.7",
-//    "org.webjars.npm"             %   "angular-animate"                         % "1.4.7",
-//    "org.webjars.npm"             %   "angular-cookies"                         % "1.4.7",
-//    "org.webjars.npm"             %   "angular-loader"                         % "1.4.7",
-//    "org.webjars.npm"             %   "angular-messages"                         % "1.4.7",
-//    "org.webjars.npm"             %   "angular-resource"                         % "1.4.7",
-//    "org.webjars.npm"             %   "angular-route"                         % "1.4.7",
-//    "org.webjars.npm"             %   "angular-sanitize"                         % "1.4.7",
-//    "org.webjars.npm"             %   "angular-touch"                         % "1.4.7",
     "org.eclipse.jetty"       %   "jetty-webapp"                      % "9.2.7.v20150116"     % "compile",
     "org.eclipse.jetty"       %   "jetty-plus"                        % "9.2.7.v20150116"     % "container,test", // For Jetty Config
     "org.eclipse.jetty.orbit" %   "javax.servlet"                     % "3.0.0.v201112011016" % "container,test" artifacts Artifact("javax.servlet", "jar", "jar"),
@@ -60,19 +39,19 @@ libraryDependencies <++= (liftVersion, version) { (lift, liftng) =>
     "org.scalatest"           %%  "scalatest"                         % "2.2.4"               % "test->*", // http://www.scalatest.org/
     "org.seleniumhq.selenium" %   "selenium-java"                     % "2.51.0"              % "test"     // http://www.seleniumhq.org/download/
   )
-}
+}.value
 
-(Keys.test in Test) <<= (Keys.test in Test) dependsOn (start in container.Configuration)
+(Keys.test in Test) := (Keys.test in Test) dependsOn (start in container.Configuration)
 
-(Keys.testOnly in Test) <<= (Keys.testOnly in Test) dependsOn (start in container.Configuration)
+(Keys.testOnly in Test) := (Keys.testOnly in Test) dependsOn (start in container.Configuration)
 
-(Keys.testQuick in Test) <<= (Keys.testOnly in Test) dependsOn (start in container.Configuration)
+(Keys.testQuick in Test) := (Keys.testOnly in Test) dependsOn (start in container.Configuration)
 
 parallelExecution in Test := false
 
 buildInfoSettings
 
-sourceGenerators in Compile <+= buildInfo
+sourceGenerators in Compile += buildInfo
 
 buildInfoKeys := Seq[BuildInfoKey](version, liftVersion, scalaVersion)
 


### PR DESCRIPTION
I'll caveat this by saying I have limited experience committing to Scala and JS projects, especially in a cross-compilation situation, so this is a learning experience for me: if I'm off target feel free to bounce the PR without letting it take up too much of your time. But I'm attempting to get a Lift 3.2/Sbt 1.0/Scala 2.12 project off the ground and wanted to utilize this library, so I thought it worthwhile to attempt to contribute towards some of the low-hanging fruit. Clearing the SBT warnings seemed like a clear precursor to resolving the dependency and versioning issues that actually arose for me (and I think I've mostly worked through).

That said! The first commit deals with bringing the sbt build file up to the modern recommendations based on (this page)[http://www.scala-sbt.org/0.13/docs/Migrating-from-sbt-012x.html]. The second commit dealt with warnings that were popping when I was running the tests to ensure they hadn't broken. It's possible some or all of the second commit should be reverted, depending on the cross-build requirements. However, since it dealt with tests only I decided to leave them in for the PR.

This PR addresses this Issue: https://github.com/joescii/lift-ng/issues/26