### PR TITLE
Make Future[Box[T]] serialize like LAFuture[Box[T]] used to

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ val copyJs = (resourceGenerators in Compile) += task {
 name := "ng"
 organization := "net.liftmodules"
 homepage := Some(url("https://github.com/joescii/lift-ng"))
-version := "0.11.1-SNAPSHOT"
+version := "0.12.0-SNAPSHOT"
 
 val liftVersion = SettingKey[String]("liftVersion", "Full version number of the Lift Web Framework")
 val liftEdition = SettingKey[String]("liftEdition", "Lift Edition (short version number to append to artifact name)")

--- a/src/main/scala/net/liftmodules/ng/FuturesConversions.scala
+++ b/src/main/scala/net/liftmodules/ng/FuturesConversions.scala
@@ -36,8 +36,10 @@ object FutureConversions {
     }
 
     lazy val boxed: FutureBox[T] = {
-      f.map(Box.legacyNullTest)
-        .recover { case t: Throwable => Failure(t.getMessage, Full(t), Empty) }
+      f.map { t =>
+        if(t.isInstanceOf[Box[_]]) t.asInstanceOf[Box[T]]
+        else Box.legacyNullTest(t)
+      }.recover { case t: Throwable => Failure(t.getMessage, Full(t), Empty) }
     }
   }
 

--- a/test-project/build.sbt
+++ b/test-project/build.sbt
@@ -2,7 +2,7 @@ name := "ng-test"
 
 organization := "net.liftmodules"
 
-version := "0.11.1-SNAPSHOT"
+version := "0.12.0-SNAPSHOT"
 
 val liftVersion = SettingKey[String]("liftVersion", "Full version number of the Lift Web Framework")
 val liftEdition = SettingKey[String]("liftEdition", "Lift Edition (short version number to append to artifact name)")

--- a/test-project/src/main/scala/net/liftmodules/ng/test/snippet/FutureSnips.scala
+++ b/test-project/src/main/scala/net/liftmodules/ng/test/snippet/FutureSnips.scala
@@ -45,6 +45,11 @@ object FutureSnips extends Loggable {
       .defFutureAny("satisfied", {
         Future { Empty }
       })
+      .defFutureAny("boxed", {
+        val p = SPromise[Box[String]]()
+        Schedule.schedule(() => p.success(Full("Boxed")), 1 second)
+        p.future
+      })
     )
   )
 }

--- a/test-project/src/main/webapp/futures.html
+++ b/test-project/src/main/webapp/futures.html
@@ -38,6 +38,10 @@
           <input id="satisfied-button" type="button" value="Satisfied" ng-click="click()"/>
           <span id="satisfied-output" ng-bind="output">Hard-coded</span>
         </div>
+        <div ng-controller="BoxedController">
+          <input id="boxed-button" type="button" value="Boxed" ng-click="click()"/>
+          <span id="boxed-output" ng-bind="output">Hard-coded</span>
+        </div>
       </div>
     </div>
   </body>

--- a/test-project/src/main/webapp/js/FutureApp.js
+++ b/test-project/src/main/webapp/js/FutureApp.js
@@ -73,4 +73,13 @@ angular.module('FutureApp', ['lift-ng', 'Futures'])
     });
   };
 }])
+.controller('BoxedController', ['$scope', 'futureServices', function($scope, svc) {
+  $scope.output = "";
+
+  $scope.click = function() {
+    svc.boxed().then(function(str){
+      $scope.output = str;
+    });
+  };
+}])
 ;

--- a/test-project/src/test/scala/net/liftmodules/ng/test/FuturesSpec.scala
+++ b/test-project/src/test/scala/net/liftmodules/ng/test/FuturesSpec.scala
@@ -47,6 +47,11 @@ class FuturesSpec extends BaseSpec {
     initialize("futures")
   }
 
+  "The angular service returning a box" should "send the string 'Boxed' up to the client after roughly 1 second" in {
+    click on "boxed-button"
+    eventually{id("boxed-output").element.text should be ("Boxed")}
+  }
+
   "The angular services" should "correctly load concurrently" in {
     click on "no-arg-button"
     click on "exception-button"
@@ -57,6 +62,7 @@ class FuturesSpec extends BaseSpec {
     click on "json-button"
     click on "empty-button"
     click on "satisfied-button"
+    click on "boxed-button"
     eventually{
       id("no-arg-output").element.text should be ("FromFuture")
       id("exception-output").element.text should be ("FromServerFutureException")
@@ -65,6 +71,7 @@ class FuturesSpec extends BaseSpec {
       id("json-output-b").element.text should be ("FromFuture argB")
       id("empty-output").element.text should be ("returned")
       id("satisfied-output").element.text should be ("satisfied")
+      id("boxed-output").element.text should be ("Boxed")
     }
   }
 


### PR DESCRIPTION
Prior to lift-ng 0.11.0, all of the API had `LAFuture[Box[T]]` and boxes were always flattened on the client. That is, a `Full("some string")` would manifest on the client simply as the string `"some string"`. With the move to Scala's built-in `Future`, we didn't retain the convention of always returning a box. Note that the signatures are `Future[T]`. We have found that since most apps are already written depending on this behavior of boxes, it would be best if any `Future[Box[T]]` encountered by lift-ng should be likewise flattened.