### PR TITLE
Session serialization and ExecutionContext

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ val copyJs = (resourceGenerators in Compile) += task {
 name := "ng"
 organization := "net.liftmodules"
 homepage := Some(url("https://github.com/joescii/lift-ng"))
-version := "0.11.1-SNAPSHOT"
+version := "0.12.0-SNAPSHOT"
 
 val liftVersion = SettingKey[String]("liftVersion", "Full version number of the Lift Web Framework")
 val liftEdition = SettingKey[String]("liftEdition", "Lift Edition (short version number to append to artifact name)")

--- a/src/main/scala/net/liftmodules/ng/Angular.scala
+++ b/src/main/scala/net/liftmodules/ng/Angular.scala
@@ -400,9 +400,9 @@ object Angular extends DispatchSnippet with AngularProperties with LiftNgJsHelpe
       */
     def defFutureAny[T <: Any]
     (functionName: String, func: => Future[T])
-    (implicit formats: Formats, ec: ExecutionContext)
+    (implicit formats: Formats, ec: ExecutionContextProvider)
     : JsObjFactory =
-      registerFunction(functionName, NoArgFutureFunctionGenerator(Unit => func))
+      registerFunction(functionName, NoArgFutureFunctionGenerator(Unit => func)(formats, ec.ec))
 
     /**
       * Registers a javascript function in this service's javascript object that takes an arbitrary parameter object and returns a

--- a/src/main/scala/net/liftmodules/ng/Angular.scala
+++ b/src/main/scala/net/liftmodules/ng/Angular.scala
@@ -272,11 +272,11 @@ object Angular extends DispatchSnippet with AngularProperties with LiftNgJsHelpe
     }
   }
 
-  private [ng] def plumbFuture[T <: Any](f: FutureBox[T], id: String)(implicit formats: Formats, ec: ExecutionContext): FutureBox[T] = {
-    S.session map { s => f foreach { box =>
+  private [ng] def plumbFuture[T <: Any](f: FutureBox[T], id: String)(implicit formats: Formats, ec: ExecutionContextProvider): FutureBox[T] = {
+    S.session map { s => f.foreach{ box =>
       // TODO: Address this deprecation warning once support for Lift 3.0.x is dropped
       s.sendCometActorMessage("LiftNgFutureActor", Empty, ReturnData(id, box, formats))
-    }}
+    }(ec.ec)}
     f
   }
 
@@ -402,7 +402,7 @@ object Angular extends DispatchSnippet with AngularProperties with LiftNgJsHelpe
     (functionName: String, func: => Future[T])
     (implicit formats: Formats, ec: ExecutionContextProvider)
     : JsObjFactory =
-      registerFunction(functionName, NoArgFutureFunctionGenerator(Unit => func)(formats, ec.ec))
+      registerFunction(functionName, NoArgFutureFunctionGenerator(Unit => func)(formats, ec))
 
     /**
       * Registers a javascript function in this service's javascript object that takes an arbitrary parameter object and returns a
@@ -414,7 +414,7 @@ object Angular extends DispatchSnippet with AngularProperties with LiftNgJsHelpe
       */
     def defParamToFutureAny[P, T <: Any]
     (functionName: String, func: P => Future[T])
-    (implicit mf: Manifest[P], formats: Formats, ec: ExecutionContext)
+    (implicit mf: Manifest[P], formats: Formats, ec: ExecutionContextProvider)
     : JsObjFactory =
       registerFunction(functionName, JsonFutureFunctionGenerator(func))
 
@@ -496,7 +496,7 @@ object Angular extends DispatchSnippet with AngularProperties with LiftNgJsHelpe
     def future[T <: Any]
       (functionName: String, func: => LAFuture[Box[T]])
       : JsObjFactory =
-      registerFunction(functionName, NoArgLAFutureFunctionGenerator(Unit => func)(DefaultFormats, AngularExecutionContext.ec))
+      registerFunction(functionName, NoArgLAFutureFunctionGenerator(Unit => func)(DefaultFormats, AngularExecutionContext.provider))
 
     /**
       * Registers a no-arg javascript function in this service's javascript object that returns a \$q promise.
@@ -510,7 +510,7 @@ object Angular extends DispatchSnippet with AngularProperties with LiftNgJsHelpe
     (functionName: String, func: => LAFuture[Box[T]])
     (implicit formats: Formats = DefaultFormats)
     : JsObjFactory =
-      registerFunction(functionName, NoArgLAFutureFunctionGenerator(Unit => func)(formats, AngularExecutionContext.ec))
+      registerFunction(functionName, NoArgLAFutureFunctionGenerator(Unit => func)(formats, AngularExecutionContext.provider))
 
     /**
      * Registers a javascript function in this service's javascript object that takes a String and returns a \$q promise.
@@ -524,7 +524,7 @@ object Angular extends DispatchSnippet with AngularProperties with LiftNgJsHelpe
       (functionName: String, func: String => LAFuture[Box[T]])
       (implicit formats: Formats = DefaultFormats)
       : JsObjFactory = {
-        implicit val ec = AngularExecutionContext.ec
+        implicit val ecp = AngularExecutionContext.provider
         registerFunction(functionName, JsonLAFutureFunctionGenerator(func))
       }
 
@@ -541,7 +541,7 @@ object Angular extends DispatchSnippet with AngularProperties with LiftNgJsHelpe
       (functionName: String, func: P => LAFuture[Box[T]])
       (implicit mf: Manifest[P], formats: Formats = DefaultFormats)
       : JsObjFactory =
-      registerFunction(functionName, JsonLAFutureFunctionGenerator(func)(mf, formats, AngularExecutionContext.ec))
+      registerFunction(functionName, JsonLAFutureFunctionGenerator(func)(mf, formats, AngularExecutionContext.provider))
 
     /**
      * Registers a javascript function in this service's javascript object that takes an arbitrary parameter object and returns a
@@ -727,7 +727,7 @@ object Angular extends DispatchSnippet with AngularProperties with LiftNgJsHelpe
     }
   }
 
-  protected case class NoArgLAFutureFunctionGenerator[T <: Any](func: Unit => LAFuture[Box[T]])(implicit formats: Formats, ec: ExecutionContext) extends FutureFunctionGenerator {
+  protected case class NoArgLAFutureFunctionGenerator[T <: Any](func: Unit => LAFuture[Box[T]])(implicit formats: Formats, ec: ExecutionContextProvider) extends FutureFunctionGenerator {
     def toAnonFunc = AnonFunc(JsReturn(Call("liftProxy.request", liftPostData)))
 
     private def liftPostData = SHtmlExtensions.ajaxJsonPost(jsonFunc(jsonToFuture))
@@ -738,7 +738,7 @@ object Angular extends DispatchSnippet with AngularProperties with LiftNgJsHelpe
     }
   }
 
-  protected case class JsonLAFutureFunctionGenerator[P, T <: Any](func: P => LAFuture[Box[T]])(implicit mf: Manifest[P], formats: Formats, ec: ExecutionContext) extends FutureFunctionGenerator {
+  protected case class JsonLAFutureFunctionGenerator[P, T <: Any](func: P => LAFuture[Box[T]])(implicit mf: Manifest[P], formats: Formats, ec: ExecutionContextProvider) extends FutureFunctionGenerator {
     private val ParamName = "json"
 
     def toAnonFunc = AnonFunc(ParamName, JsReturn(Call("liftProxy.request", liftPostData)))
@@ -759,7 +759,7 @@ object Angular extends DispatchSnippet with AngularProperties with LiftNgJsHelpe
     }
   }
 
-  protected case class NoArgFutureFunctionGenerator[T <: Any](func: Unit => Future[T])(implicit formats: Formats, ec: ExecutionContext) extends FutureFunctionGenerator {
+  protected case class NoArgFutureFunctionGenerator[T <: Any](func: Unit => Future[T])(implicit formats: Formats, ec: ExecutionContextProvider) extends FutureFunctionGenerator {
     def toAnonFunc = AnonFunc(JsReturn(Call("liftProxy.request", liftPostData)))
 
     private def liftPostData = SHtmlExtensions.ajaxJsonPost(jsonFunc(jsonToFuture))
@@ -770,7 +770,7 @@ object Angular extends DispatchSnippet with AngularProperties with LiftNgJsHelpe
     }
   }
 
-  protected case class JsonFutureFunctionGenerator[P, T <: Any](func: P => Future[T])(implicit mf: Manifest[P], formats: Formats, ec: ExecutionContext) extends FutureFunctionGenerator {
+  protected case class JsonFutureFunctionGenerator[P, T <: Any](func: P => Future[T])(implicit mf: Manifest[P], formats: Formats, ec: ExecutionContextProvider) extends FutureFunctionGenerator {
     private val ParamName = "json"
 
     def toAnonFunc = AnonFunc(ParamName, JsReturn(Call("liftProxy.request", liftPostData)))
@@ -827,9 +827,9 @@ object Angular extends DispatchSnippet with AngularProperties with LiftNgJsHelpe
           handleFailure(throwableToFailure(t))
       }
 
-    protected def tryFuture[A, T <: Any](a: => A, f: A => Future[T])(implicit ec: ExecutionContext): FutureBox[T] =
+    protected def tryFuture[A, T <: Any](a: => A, f: A => Future[T])(implicit ec: ExecutionContextProvider): FutureBox[T] =
       try {
-        f(a).boxed
+        boxed(f(a))
       } catch {
         case t: Throwable =>
           Future.failed(t)

--- a/src/main/scala/net/liftmodules/ng/ExecutionContextProvider.scala
+++ b/src/main/scala/net/liftmodules/ng/ExecutionContextProvider.scala
@@ -1,0 +1,27 @@
+package net.liftmodules.ng
+
+import scala.concurrent.ExecutionContext
+
+object AngularExecutionContext {
+  implicit var ec: ExecutionContext = ExecutionContext.global
+  def apply(ec: ExecutionContext) {
+    this.ec = ec
+  }
+}
+
+trait ExecutionContextProvider {
+  def ec: ExecutionContext
+}
+
+object ExecutionContextProvider {
+  implicit class EnhancedExecutionContext(e: ExecutionContext) {
+    def asProvider: ExecutionContextProvider = new ExecutionContextProvider {
+      override def ec: ExecutionContext = e
+    }
+  }
+
+  val globalSerializable: ExecutionContextProvider = new ExecutionContextProvider with Serializable {
+    override def ec: ExecutionContext = ExecutionContext.global
+  }
+}
+

--- a/src/main/scala/net/liftmodules/ng/ExecutionContextProvider.scala
+++ b/src/main/scala/net/liftmodules/ng/ExecutionContextProvider.scala
@@ -2,15 +2,17 @@ package net.liftmodules.ng
 
 import scala.concurrent.ExecutionContext
 
-object AngularExecutionContext { self =>
-  implicit var ec: ExecutionContext = ExecutionContext.global
+object AngularExecutionContext {
+  private var _ec: ExecutionContext = ExecutionContext.global
 
   def apply(ec: ExecutionContext) {
-    this.ec = ec
+    this._ec = ec
   }
 
+  implicit def ec: ExecutionContext = _ec
+
   implicit val provider: ExecutionContextProvider = new ExecutionContextProvider {
-    override def ec: ExecutionContext = self.ec
+    override def ec: ExecutionContext = _ec
   }
 }
 

--- a/src/main/scala/net/liftmodules/ng/ExecutionContextProvider.scala
+++ b/src/main/scala/net/liftmodules/ng/ExecutionContextProvider.scala
@@ -2,10 +2,15 @@ package net.liftmodules.ng
 
 import scala.concurrent.ExecutionContext
 
-object AngularExecutionContext {
+object AngularExecutionContext { self =>
   implicit var ec: ExecutionContext = ExecutionContext.global
+
   def apply(ec: ExecutionContext) {
     this.ec = ec
+  }
+
+  val provider: ExecutionContextProvider = new ExecutionContextProvider {
+    override def ec: ExecutionContext = self.ec
   }
 }
 

--- a/src/main/scala/net/liftmodules/ng/ExecutionContextProvider.scala
+++ b/src/main/scala/net/liftmodules/ng/ExecutionContextProvider.scala
@@ -9,7 +9,7 @@ object AngularExecutionContext { self =>
     this.ec = ec
   }
 
-  val provider: ExecutionContextProvider = new ExecutionContextProvider {
+  implicit val provider: ExecutionContextProvider = new ExecutionContextProvider {
     override def ec: ExecutionContext = self.ec
   }
 }

--- a/src/main/scala/net/liftmodules/ng/FuturesConversions.scala
+++ b/src/main/scala/net/liftmodules/ng/FuturesConversions.scala
@@ -7,13 +7,15 @@ import net.liftweb.json.{Formats, JValue}
 
 import scala.util.{Success, Failure => SFailure}
 
+import ExecutionContextProvider._
+
 trait ScalaFutureSerializer {
-  def scalaFutureSerializer(formats: Formats)(implicit ec: ExecutionContext): PartialFunction[Any, JValue] = {
-    case future: Future[_] => LAFutureSerializer.laFuture2JValue(formats, FutureConversions.FutureToLAFuture(future))
+  def scalaFutureSerializer(formats: Formats)(implicit ec: ExecutionContextProvider): PartialFunction[Any, JValue] = {
+    case future: Future[_] => LAFutureSerializer.laFuture2JValue(formats, FutureConversions.FutureToLAFuture(future)(ec.ec))
   }
 }
 
-object FutureConversions {
+object FutureConversions { conversions =>
   implicit def FutureToLAFuture[T](f: Future[T])(implicit ec: ExecutionContext):LAFuture[Box[T]] = f.la
 
   implicit class ConvertToLA[T](f: Future[T])(implicit ec: ExecutionContext) {
@@ -28,11 +30,13 @@ object FutureConversions {
       laf
     }
 
-    lazy val boxed: FutureBox[T] = {
-      f.map(Box.legacyNullTest)
-        .recover { case t: Throwable => Failure(t.getMessage, Full(t), Empty) }
-    }
+    lazy val boxed: FutureBox[T] = conversions.boxed(f)(ec.asProvider)
   }
+
+  def boxed[T](f: Future[T])(implicit ecp: ExecutionContextProvider): FutureBox[T] =
+    f.map(Box.legacyNullTest)(ecp.ec)
+      .recover { case t: Throwable => Failure(t.getMessage, Full(t), Empty) } (ecp.ec)
+
 
   def LAFutureToFuture[T](f: LAFuture[Box[T]]): FutureBox[T] = {
       val p: Promise[Box[T]] = Promise()

--- a/src/main/scala/net/liftmodules/ng/FuturesConversions.scala
+++ b/src/main/scala/net/liftmodules/ng/FuturesConversions.scala
@@ -7,13 +7,6 @@ import net.liftweb.json.{Formats, JValue}
 
 import scala.util.{Success, Failure => SFailure}
 
-object AngularExecutionContext {
-  implicit var ec: ExecutionContext = ExecutionContext.global
-  def apply(ec: ExecutionContext) {
-    this.ec = ec
-  }
-}
-
 trait ScalaFutureSerializer {
   def scalaFutureSerializer(formats: Formats)(implicit ec: ExecutionContext): PartialFunction[Any, JValue] = {
     case future: Future[_] => LAFutureSerializer.laFuture2JValue(formats, FutureConversions.FutureToLAFuture(future))

--- a/src/main/scala/net/liftmodules/ng/LAFutureSerializer.scala
+++ b/src/main/scala/net/liftmodules/ng/LAFutureSerializer.scala
@@ -10,7 +10,7 @@ import common._
 import scala.concurrent.ExecutionContext
 
 object LAFutureSerializer {
-  def laFuture2JValue[T](formats: Formats, future: LAFuture[Box[T]])(implicit ec: ExecutionContext) = {
+  def laFuture2JValue[T](formats: Formats, future: LAFuture[Box[T]])(implicit ec: ExecutionContextProvider) = {
     implicit val f = formats + new LAFutureSerializer
 
     val id = rand
@@ -29,7 +29,7 @@ object LAFutureSerializer {
     JObject(List(flagField)) merge valObj
   }
 
-  def laFutureSerializer(formats: Formats, ec: ExecutionContext): PartialFunction[Any, JValue] = {
+  def laFutureSerializer(formats: Formats, ec: ExecutionContextProvider): PartialFunction[Any, JValue] = {
     case future: LAFuture[_] => laFuture2JValue(formats, future.asInstanceOf[LAFuture[Box[Any]]])(ec)
   }
 
@@ -56,5 +56,5 @@ class LAFutureSerializer[T : Manifest] extends Serializer[LAFuture[Box[T]]] with
       else throw new MappingException("Can't convert " + json + " to " + Class)
   }
 
-  def serialize(implicit format: Formats) = laFutureSerializer(format, ec) orElse scalaFutureSerializer(format)
+  def serialize(implicit format: Formats) = laFutureSerializer(format, provider) orElse scalaFutureSerializer(format)(provider)
 }

--- a/test-project/build.sbt
+++ b/test-project/build.sbt
@@ -2,7 +2,7 @@ name := "ng-test"
 
 organization := "net.liftmodules"
 
-version := "0.11.1-SNAPSHOT"
+version := "0.12.0-SNAPSHOT"
 
 val liftVersion = SettingKey[String]("liftVersion", "Full version number of the Lift Web Framework")
 val liftEdition = SettingKey[String]("liftEdition", "Lift Edition (short version number to append to artifact name)")

--- a/test-project/src/main/scala/net/liftmodules/ng/test/comet/AsyncTestActors.scala
+++ b/test-project/src/main/scala/net/liftmodules/ng/test/comet/AsyncTestActors.scala
@@ -9,7 +9,7 @@ import util._
 import Helpers._
 import java.util.concurrent.ScheduledFuture
 import net.liftmodules.ng.test.snippet.EmbeddedFuturesSnips
-import scala.concurrent.ExecutionContext.Implicits.global
+import AngularExecutionContext._
 
 abstract class AsyncTestActor extends AngularActor with Loggable {
   self =>

--- a/test-project/src/main/scala/net/liftmodules/ng/test/snippet/EmbeddedFuturesSnips.scala
+++ b/test-project/src/main/scala/net/liftmodules/ng/test/snippet/EmbeddedFuturesSnips.scala
@@ -2,6 +2,7 @@ package net.liftmodules.ng
 package test.snippet
 
 import Angular._
+import ExecutionContextProvider._
 import net.liftweb.actor.LAFuture
 import net.liftmodules.ng.test.model.StringInt
 import net.liftweb.common.{Box, Empty, Failure, Full}
@@ -40,7 +41,7 @@ case class EmbeddedScalaFutures(
 )
 
 object EmbeddedFuturesSnips {
-  import scala.concurrent.ExecutionContext.Implicits.global
+  implicit val ecp = scala.concurrent.ExecutionContext.Implicits.global.asProvider
   implicit val formats = DefaultFormats
 
   def services = renderIfNotAlreadyDefined(

--- a/test-project/src/main/scala/net/liftmodules/ng/test/snippet/EmbeddedFuturesSnips.scala
+++ b/test-project/src/main/scala/net/liftmodules/ng/test/snippet/EmbeddedFuturesSnips.scala
@@ -2,7 +2,6 @@ package net.liftmodules.ng
 package test.snippet
 
 import Angular._
-import ExecutionContextProvider._
 import net.liftweb.actor.LAFuture
 import net.liftmodules.ng.test.model.StringInt
 import net.liftweb.common.{Box, Empty, Failure, Full}
@@ -12,8 +11,9 @@ import net.liftweb.util.Helpers._
 import net.liftweb.http.S
 import net.liftweb.json.DefaultFormats
 
+import AngularExecutionContext._
+
 import scala.concurrent.{Future, Promise => ScalaPromise}
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.Try
 
 case class EmbeddedFutures(
@@ -41,7 +41,6 @@ case class EmbeddedScalaFutures(
 )
 
 object EmbeddedFuturesSnips {
-  implicit val ecp = scala.concurrent.ExecutionContext.Implicits.global.asProvider
   implicit val formats = DefaultFormats
 
   def services = renderIfNotAlreadyDefined(

--- a/test-project/src/main/scala/net/liftmodules/ng/test/snippet/FailureSnips.scala
+++ b/test-project/src/main/scala/net/liftmodules/ng/test/snippet/FailureSnips.scala
@@ -3,6 +3,7 @@ package test.snippet
 
 import test.model._
 import Angular._
+import ExecutionContextProvider._
 import net.liftweb.common._
 import net.liftweb.json.DefaultFormats
 import net.liftweb.util.Schedule
@@ -13,6 +14,7 @@ import scala.xml.NodeSeq
 import scala.concurrent.ExecutionContext.Implicits.global
 
 object FailureSnips {
+  implicit val ecp = scala.concurrent.ExecutionContext.Implicits.global.asProvider
   implicit val formats = DefaultFormats
   case class TestException(msg: String) extends Exception
 

--- a/test-project/src/main/scala/net/liftmodules/ng/test/snippet/FailureSnips.scala
+++ b/test-project/src/main/scala/net/liftmodules/ng/test/snippet/FailureSnips.scala
@@ -3,18 +3,16 @@ package test.snippet
 
 import test.model._
 import Angular._
-import ExecutionContextProvider._
 import net.liftweb.common._
 import net.liftweb.json.DefaultFormats
 import net.liftweb.util.Schedule
 import net.liftweb.util.Helpers._
+import AngularExecutionContext._
 
 import scala.concurrent.Future
 import scala.xml.NodeSeq
-import scala.concurrent.ExecutionContext.Implicits.global
 
 object FailureSnips {
-  implicit val ecp = scala.concurrent.ExecutionContext.Implicits.global.asProvider
   implicit val formats = DefaultFormats
   case class TestException(msg: String) extends Exception
 

--- a/test-project/src/main/scala/net/liftmodules/ng/test/snippet/FutureSnips.scala
+++ b/test-project/src/main/scala/net/liftmodules/ng/test/snippet/FutureSnips.scala
@@ -2,6 +2,7 @@ package net.liftmodules.ng
 package test.snippet
 
 import Angular._
+import ExecutionContextProvider._
 import test.model.Test2Obj
 import net.liftweb._
 import common._
@@ -10,10 +11,11 @@ import util.Schedule
 import util.Helpers._
 
 import scala.xml.NodeSeq
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ Future, Promise => SPromise }
+import scala.concurrent.ExecutionContext.Implicits.global
 
 object FutureSnips extends Loggable {
+  implicit val ecp = scala.concurrent.ExecutionContext.Implicits.global.asProvider
   implicit val formats = DefaultFormats
 
   def services(xhtml:NodeSeq) = renderIfNotAlreadyDefined(

--- a/test-project/src/main/scala/net/liftmodules/ng/test/snippet/FutureSnips.scala
+++ b/test-project/src/main/scala/net/liftmodules/ng/test/snippet/FutureSnips.scala
@@ -2,20 +2,18 @@ package net.liftmodules.ng
 package test.snippet
 
 import Angular._
-import ExecutionContextProvider._
 import test.model.Test2Obj
 import net.liftweb._
 import common._
 import net.liftweb.json.DefaultFormats
 import util.Schedule
 import util.Helpers._
+import AngularExecutionContext._
 
 import scala.xml.NodeSeq
 import scala.concurrent.{ Future, Promise => SPromise }
-import scala.concurrent.ExecutionContext.Implicits.global
 
 object FutureSnips extends Loggable {
-  implicit val ecp = scala.concurrent.ExecutionContext.Implicits.global.asProvider
   implicit val formats = DefaultFormats
 
   def services(xhtml:NodeSeq) = renderIfNotAlreadyDefined(

--- a/test-project/src/main/scala/net/liftmodules/ng/test/snippet/FuturesRaceCondition.scala
+++ b/test-project/src/main/scala/net/liftmodules/ng/test/snippet/FuturesRaceCondition.scala
@@ -1,10 +1,10 @@
 package net.liftmodules.ng.test.snippet
 
 import net.liftmodules.ng.Angular._
+import net.liftmodules.ng.AngularExecutionContext._
 import net.liftweb.common.Full
 import net.liftweb.json.DefaultFormats
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent._
 
 case class FuturesRaceConditionModel(


### PR DESCRIPTION
This branch replaces `ExecutionContext` with `ExecutionContextProvider` on the public APIs of lift-ng. `ExecutionContext` is not a serializable object, and having it as function parameters breaks serialization of the service functions, and hence is incompatible with clustering. `ExecutionContextProvider` gives us a wrapper which can be implemented with serializability in mind for users of lift-cluster. 