### PR TITLE
liftproxy.js - do not call e.scope() for comet-updates

### DIFF
--- a/src/main/js/liftproxy.js
+++ b/src/main/js/liftproxy.js
@@ -1,6 +1,6 @@
 angular
   .module("lift-ng", [])
-  .service("plumbing", [ "$q", function($q){
+  .service("plumbing", [ "$rootScope", "$q", function($rootScope, $q){
     var defers = {};
 
     var getOrCreate = function(id) {
@@ -40,6 +40,12 @@ angular
         resolve(response, getOrCreate(id));
       }
     };
+    
+    var fulfillAndApply = function(response, id) {
+      	$rootScope.$apply(function() {
+      		fulfill(response, id);
+      	});
+    }
 
     // Called to inject promises wherever our serializer encountered a Future
     var inject = function(model) {
@@ -79,6 +85,7 @@ angular
       getOrCreateDefer: getOrCreate,
       resolve: resolve,
       fulfill: fulfill,
+      fulfillAndApply: fulfillAndApply,
       inject: inject
     }
   }])
@@ -272,7 +279,7 @@ angular
       i=0;
       for(l=es.length;i<l;i++){
         e=angular.element(es[i]);
-        e.scope().$apply(function(){e.injector().get('plumbing').fulfill(r, d)});
+        e.injector().get('plumbing').fulfillAndApply(r, d);
       }
   };
 


### PR DESCRIPTION
Hey Joe, please have a look. This references the angular production issue
https://github.com/joescii/lift-ng/issues/36
 - allows the app to run with angular.debugInfoEnabled(false)

I tested this on a project and it seems to work fine. It works by injecting the rootScope through your plumbing service. I think this approach is simpler than the branch `expose-scope` that you have created. 

For me this fixes lift-ng comet not working in production, but I have not fully tested it. Maybe there is another place that uses `element.scope()`? 

Let me know what you think. I can help you make this ready for release.

Regards
Robert